### PR TITLE
Redo flight movement calculations

### DIFF
--- a/src/main/java/me/dags/daflight/handler/MovementHandler.java
+++ b/src/main/java/me/dags/daflight/handler/MovementHandler.java
@@ -91,36 +91,35 @@ public class MovementHandler {
     }
 
     private void moveFlying(Vector3d direction, Rotation rotation) {
-        double x = 0;
-        double y = 0;
-        double z = 0;
-        double rads = Math.toRadians(rotation.getYaw());
-        double dx = -Math.sin(rads);
-        double dz = Math.cos(rads);
+        double x, y, z;
+        double yaw = Math.toRadians(rotation.getYaw());
+        double pitch = Math.toRadians(rotation.getPitch());
         float boost = flyBoosting ? daFlight.config().flyBoost : 1F;
 
-        if (moveForward != 0) {
-            x += dx * moveForward * clamp(daFlight.config().flySpeed * boost, maxFlySpeed);
-            z += dz * moveForward * clamp(daFlight.config().flySpeed * boost, maxFlySpeed);
+        if (daFlight.config().flight3D) {
+            x = moveForward * -Math.sin(yaw) * Math.abs(Math.cos(pitch));
+            y = moveForward * -Math.sin(pitch);
+            z = moveForward * Math.cos(yaw) * Math.abs(Math.cos(pitch));
+        } else {
+            x = moveForward * -Math.sin(yaw);
+            y = 0;
+            z = moveForward * Math.cos(yaw);
         }
-        if (moveStrafe != 0) {
-            x += dz * moveStrafe * clamp(daFlight.config().flySpeed * daFlight.config().strafeModifier * boost, maxFlySpeed);
-            z += dx * -moveStrafe * clamp(daFlight.config().flySpeed * daFlight.config().strafeModifier * boost, maxFlySpeed);
-        }
-        if (moveForward != 0 && moveStrafe != 0) {
-            x *= SCALE_FACTOR;
-            z *= SCALE_FACTOR;
-        }
-        if (daFlight.config().flight3D && moveForward != 0) {
-            y += -rotation.getPitch() * moveForward * (0.9F / 50F) * daFlight.config().verticalModifier * clamp(daFlight.config().flySpeed * boost, maxFlySpeed);
-        }
+
+        x += moveStrafe * Math.cos(yaw);
+        z += moveStrafe * Math.sin(yaw);
+
         if (DaFlight.instance().inputHandler().getFlyUpBind().keyHeld() && MCHooks.Game.inGameHasFocus()) {
-            y += clamp(daFlight.config().flySpeed * boost * daFlight.config().verticalModifier, maxFlySpeed);
+            y += 1;
         }
+
         if (DaFlight.instance().inputHandler().getFlyDownBind().keyHeld() && MCHooks.Game.inGameHasFocus()) {
-            y -= clamp(daFlight.config().flySpeed * boost * daFlight.config().verticalModifier, maxFlySpeed);
+            y -= 1;
         }
+
         direction.update(x, y, z);
+        direction.normalize();
+        direction.mult(clamp(daFlight.config().flySpeed * boost, maxFlySpeed));
     }
 
     private void moveSprinting(Vector3d direction, Rotation rotation) {

--- a/src/main/java/me/dags/daflight/util/Vector3d.java
+++ b/src/main/java/me/dags/daflight/util/Vector3d.java
@@ -39,4 +39,25 @@ public class Vector3d {
         z *= z;
         return this;
     }
+
+	public Vector3d mult(double s) {
+		x *= s;
+		y *= s;
+		z *= s;
+		return this;
+	}
+
+	public Vector3d normalize() {
+		if (this.length() == 0) {
+			return this;
+		}
+		x /= this.length();
+		y /= this.length();
+		z /= this.length();
+		return this;
+	}
+
+	public double length() {
+		return Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2) + Math.pow(z, 2));
+	}
 }


### PR DESCRIPTION
This PR completely changes how the flight movement is being calculated.
First it creates a vector that points in the right direction, normalises this vector to length 1 and then multiplies it with the desired speed.

The main benefit of this is that the speed calculation is in a single place. It also makes the speed constant — with the previous system going up/down with the key bind actually made you faster.

Another change is that the lateral movement during 3D flight now takes pitch into account. This means that you actually go where you are pointing.
Previously, this was only the case when there was no vertical component. This was most obvious when going straight up or down — there was still some lateral movement.